### PR TITLE
test: MS-002 enforce admin gate regression for dev decision endpoint

### DIFF
--- a/Aegis-Implementation-Todos.md
+++ b/Aegis-Implementation-Todos.md
@@ -236,7 +236,7 @@ E2E-1 → E2E-2 → E2E-3 → E2E-4 → E2E-5   # 最后跑通全流程
 |---|------|------|
 | 1 | 文档 | REST 示例需含 `idempotency_key`、`recipient_reference`（已补充） |
 | 2 | API | `idempotency_key` 建议统一为 Header |
-| 3 | Dev | `POST /api/dev/actions/:id/decision` 需 admin 登录 |
+| 3 | Dev | `POST /api/dev/actions/:id/decision` 需 admin 登录（✅ 已由中间件保护，测试覆盖：`tests/app.test.ts`） |
 | 4 | MCP | `recipient_reference` 可扩展为可选参数 |
 
 ---

--- a/docs/milestones/MS-002-admin-gate-dev-decision.md
+++ b/docs/milestones/MS-002-admin-gate-dev-decision.md
@@ -1,0 +1,17 @@
+# Milestone: MS-002 Admin Gate for Dev Decision Endpoint
+
+## Priority Source
+
+来源：`/Users/bowenwang/Holdis/repo/Aegis-Implementation-Todos.md` §6.6 Bug 列表 #3。  
+目标：确保 `POST /api/dev/actions/:actionId/decision` 必须通过 admin 登录。
+
+## Acceptance Criteria
+
+1. 未携带 admin session cookie 调用 `POST /api/dev/actions/:actionId/decision` 返回 `401`。
+2. 携带有效 admin session cookie 调用同端点可正常执行决策（200）。
+3. 增加回归测试，覆盖“未登录拒绝 + 已登录放行”两种行为。
+4. `make test`、`make coverage`、`make ci` 全绿。
+
+## Scope
+
+- 只做回归保障，不改变业务行为与权限模型。

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -32,6 +32,34 @@ describe('Aegis MVP prototype', () => {
     await api.get('/dev/passkeys').set('Cookie', [adminCookie]).expect(200);
   });
 
+  it('requires admin login for POST /api/dev/actions/:actionId/decision', async () => {
+    const api = request(runtime.app);
+    const create = await api
+      .post('/v1/request_action')
+      .set('x-aegis-api-key', 'aegis_demo_agent_key')
+      .send({
+        idempotency_key: 't_admin_gate_decision_1',
+        end_user_id: 'usr_demo',
+        action_type: 'payment',
+        details: {
+          amount: '12.34',
+          currency: 'USD',
+          recipient_name: 'Admin Gate Merchant',
+          description: 'admin gate test',
+          payment_rail: 'card',
+          payment_method_preference: 'card_default',
+          recipient_reference: 'merchant_api:admin_gate',
+        },
+      })
+      .expect(201);
+    const actionId = String(create.body.action.action_id);
+
+    await api.post(`/api/dev/actions/${actionId}/decision`).send({ decision: 'approve' }).expect(401);
+
+    const adminCookie = await adminLogin(api);
+    await api.post(`/api/dev/actions/${actionId}/decision`).set('Cookie', [adminCookie]).send({ decision: 'deny' }).expect(200);
+  });
+
   it('creates, approves, executes, and callbacks for card rail', async () => {
     const api = request(runtime.app);
     const adminCookie = await adminLogin(api);


### PR DESCRIPTION
## What changed
- Added milestone spec: `docs/milestones/MS-002-admin-gate-dev-decision.md`.
- Added regression test ensuring `POST /api/dev/actions/:actionId/decision` is protected by admin auth:
  - unauthenticated call returns 401
  - authenticated admin call succeeds
- Updated TODO note in `Aegis-Implementation-Todos.md` to reflect enforced gate and test coverage.

## How to verify
```bash
make test
make coverage
make ci
```

## Coverage summary
`make coverage`:
- Global: Statements `87.02%`, Branches `73.8%`, Functions `85.18%`, Lines `88.06%`
- Key module `src/routes/api.ts`: Statements `86.81%`, Branches `73.8%`, Functions `85.18%`, Lines `87.86%`
