### PR TITLE
[#6] Harden app auth boundary

### DIFF
--- a/src/routes/app.ts
+++ b/src/routes/app.ts
@@ -31,32 +31,6 @@ function requireAppSession(service: AegisService) {
   };
 }
 
-/**
- * Validates that the supplied user_id belongs to an active end user.
- * NOTE: This is NOT full authentication — it only prevents calls with
- * unknown/inactive user IDs. A proper login + session system is required
- * before production launch. See TODO below.
- */
-function requireValidUser(service: AegisService) {
-  return (req: Request, _res: Response, next: NextFunction) => {
-    // TODO(auth): Replace this with real session/JWT auth before production.
-    // Currently there is no proof that the caller IS the user — only that the
-    // user_id exists. This is acceptable for the MVP demo but is a security
-    // gap that MUST be closed before any real funds are handled.
-    const userId = String((req.query.user_id ?? req.body?.user_id) ?? '').trim();
-    if (!userId) {
-      return next(new DomainError('MISSING_USER_ID', 'user_id is required', 400));
-    }
-    const endUser = service.getStore().getEndUserById(userId);
-    if (!endUser || endUser.status !== 'active') {
-      return next(new DomainError('INVALID_USER', 'Unknown or inactive user', 403));
-    }
-    (req as any).validatedUserId = userId;
-    (req as any).validatedEndUser = endUser;
-    next();
-  };
-}
-
 function assertActiveUserForActionIdBranch(service: AegisService, userId: string): void {
   const endUser = service.getStore().getEndUserById(userId);
   if (!endUser || endUser.status !== 'active') {
@@ -71,9 +45,9 @@ function assertActiveUserForActionIdBranch(service: AegisService, userId: string
 export function createAppRouter(service: AegisService): Router {
   const router = Router();
 
-  router.get('/api/app/pending', requireValidUser(service), (req, res, next) => {
+  router.get('/api/app/pending', requireAppSession(service), (req, res, next) => {
     try {
-      const userId = (req as any).validatedUserId as string;
+      const userId = (req as any).appUserId as string;
       const store = service.getStore();
       const items = store.listActionsByUserAndStatus(userId, 'awaiting_approval');
       res.json({
@@ -85,9 +59,9 @@ export function createAppRouter(service: AegisService): Router {
     }
   });
 
-  router.get('/api/app/history', requireValidUser(service), (req, res, next) => {
+  router.get('/api/app/history', requireAppSession(service), (req, res, next) => {
     try {
-      const userId = (req as any).validatedUserId as string;
+      const userId = (req as any).appUserId as string;
       const limit = Math.max(1, Math.min(200, Number(req.query.limit) || 50));
       const offset = Math.max(0, Number(req.query.offset) || 0);
       const store = service.getStore();
@@ -139,11 +113,15 @@ export function createAppRouter(service: AegisService): Router {
       let view: ReturnType<typeof service.getApprovalView | typeof service.getApprovalViewByActionId>;
       if (token) {
         view = service.getApprovalView(token);
-      } else if (actionId && userId) {
-        assertActiveUserForActionIdBranch(service, userId);
-        view = service.getApprovalViewByActionId(actionId, userId);
+      } else if (actionId) {
+        const sessionUserId = getSessionUserIdOrThrow(service, req);
+        if (userId && userId !== sessionUserId) {
+          throw new DomainError('APPROVAL_NOT_ASSIGNED_TO_USER', 'Action is not assigned to this user', 403);
+        }
+        assertActiveUserForActionIdBranch(service, sessionUserId);
+        view = service.getApprovalViewByActionId(actionId, sessionUserId);
       } else {
-        throw new DomainError('MISSING_PARAMS', 'Provide token OR action_id+user_id', 400);
+        throw new DomainError('MISSING_PARAMS', 'Provide token OR action_id', 400);
       }
 
       if (!view.valid) {
@@ -177,8 +155,8 @@ export function createAppRouter(service: AegisService): Router {
       const actionId = String(req.body?.action_id ?? '').trim();
       const userId = String(req.body?.user_id ?? '').trim();
 
-      if (!token && !(actionId && userId)) {
-        throw new DomainError('MISSING_PARAMS', 'Provide token OR action_id+user_id', 400);
+      if (!token && !actionId) {
+        throw new DomainError('MISSING_PARAMS', 'Provide token OR action_id', 400);
       }
       const decision = String(req.body?.decision ?? '').toLowerCase();
       if (decision !== 'approve' && decision !== 'deny') {
@@ -193,8 +171,12 @@ export function createAppRouter(service: AegisService): Router {
       if (token) {
         action = service.submitApprovalDecision(token, decision as 'approve' | 'deny', sourceRaw as DecisionSource);
       } else {
-        assertActiveUserForActionIdBranch(service, userId);
-        action = service.submitDecisionByActionId(actionId, userId, decision as 'approve' | 'deny', sourceRaw as DecisionSource);
+        const sessionUserId = getSessionUserIdOrThrow(service, req);
+        if (userId && userId !== sessionUserId) {
+          throw new DomainError('APPROVAL_NOT_ASSIGNED_TO_USER', 'Action is not assigned to this user', 403);
+        }
+        assertActiveUserForActionIdBranch(service, sessionUserId);
+        action = service.submitDecisionByActionId(actionId, sessionUserId, decision as 'approve' | 'deny', sourceRaw as DecisionSource);
       }
 
       res.json({
@@ -208,9 +190,9 @@ export function createAppRouter(service: AegisService): Router {
     }
   });
 
-  router.post('/api/app/devices', requireValidUser(service), (req, res, next) => {
+  router.post('/api/app/devices', requireAppSession(service), (req, res, next) => {
     try {
-      const userId = (req as any).validatedUserId as string;
+      const userId = (req as any).appUserId as string;
       const platform = String(req.body?.platform ?? '').trim();
       const pushToken = String(req.body?.push_token ?? '').trim();
       if (platform !== 'ios' && platform !== 'android') {
@@ -224,9 +206,9 @@ export function createAppRouter(service: AegisService): Router {
     }
   });
 
-  router.get('/api/app/devices', requireValidUser(service), (req, res, next) => {
+  router.get('/api/app/devices', requireAppSession(service), (req, res, next) => {
     try {
-      const userId = (req as any).validatedUserId as string;
+      const userId = (req as any).appUserId as string;
       const devices = service.getStore().listDevicesForUser(userId);
       res.json({ devices });
     } catch (error) {
@@ -234,9 +216,9 @@ export function createAppRouter(service: AegisService): Router {
     }
   });
 
-  router.delete('/api/app/devices/:id', requireValidUser(service), (req, res, next) => {
+  router.delete('/api/app/devices/:id', requireAppSession(service), (req, res, next) => {
     try {
-      const userId = (req as any).validatedUserId as string;
+      const userId = (req as any).appUserId as string;
       const deviceId = String(req.params.id);
       const store = service.getStore();
       const devices = store.listDevicesForUser(userId);
@@ -460,4 +442,17 @@ export function createAppRouter(service: AegisService): Router {
   });
 
   return router;
+}
+
+function getSessionUserIdOrThrow(service: AegisService, req: Request): string {
+  const config = service.getConfig();
+  const token = (req.cookies?.[config.appSessionCookieName] ?? req.cookies?.aegis_app_session) as string | undefined;
+  if (!token) {
+    throw new DomainError('UNAUTHORIZED', 'App session required. Log in via magic link.', 401);
+  }
+  const session = service.getStore().findAppSessionByToken(token);
+  if (!session) {
+    throw new DomainError('UNAUTHORIZED', 'Invalid or expired session', 401);
+  }
+  return session.endUserId;
 }

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -442,9 +442,10 @@ describe('Aegis MVP prototype', () => {
     expect(final.body.action.status).toBe('succeeded');
   });
 
-  it('app approval API: GET/POST by action_id+user_id (no token needed)', async () => {
+  it('app approval API: GET/POST by action_id requires app session', async () => {
     const api = request(runtime.app);
     const adminCookie = await adminLogin(api);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
     const create = await api
       .post('/v1/request_action')
       .set('x-aegis-api-key', 'aegis_demo_agent_key')
@@ -467,22 +468,18 @@ describe('Aegis MVP prototype', () => {
 
     const actionId = String(create.body.action.action_id);
 
-    const getRes = await api
-      .get(`/api/app/approval?action_id=${actionId}&user_id=usr_demo`)
-      .expect(200);
+    const getRes = await api.get(`/api/app/approval?action_id=${actionId}`).set('Cookie', [appCookie]).expect(200);
     expect(getRes.body.valid).toBe(true);
     expect(getRes.body.already_decided).toBe(false);
     expect(getRes.body.action.details.amount).toBe('18.00');
     expect(getRes.body.action.created_at).toBeTruthy();
 
-    const wrongUser = await api
-      .get(`/api/app/approval?action_id=${actionId}&user_id=usr_other`)
-      .expect(403);
-    expect(wrongUser.body.error).toBe('INVALID_USER');
+    await api.get(`/api/app/approval?action_id=${actionId}`).expect(401);
 
     await api
       .post('/api/app/approval/decision')
-      .send({ action_id: actionId, user_id: 'usr_demo', decision: 'approve', decision_source: 'app_biometric' })
+      .set('Cookie', [appCookie])
+      .send({ action_id: actionId, decision: 'approve', decision_source: 'app_biometric' })
       .expect(200);
 
     await api.post('/api/dev/workers/tick').set('Cookie', [adminCookie]).send({}).expect(200);
@@ -494,6 +491,7 @@ describe('Aegis MVP prototype', () => {
   it('GET /api/app/pending returns only awaiting_approval actions for user', async () => {
     const api = request(runtime.app);
     const adminCookie = await adminLogin(api);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
 
     const makeAction = async (idempKey: string, amount: string) => {
       const res = await api
@@ -523,7 +521,7 @@ describe('Aegis MVP prototype', () => {
     const deniedId = await makeAction('t_pending_list_denied', '3.00');
     await api.post(`/api/dev/actions/${deniedId}/decision`).set('Cookie', [adminCookie]).send({ decision: 'deny' }).expect(200);
 
-    const pendingRes = await api.get('/api/app/pending?user_id=usr_demo').expect(200);
+    const pendingRes = await api.get('/api/app/pending').set('Cookie', [appCookie]).expect(200);
     expect(pendingRes.body.count).toBeGreaterThanOrEqual(2);
     const pendingIds = pendingRes.body.items.map((i: any) => i.action_id);
     expect(pendingIds).toContain(pendingId1);
@@ -533,17 +531,15 @@ describe('Aegis MVP prototype', () => {
       expect(item.status).toBe('awaiting_approval');
     }
 
-    const emptyRes = await api.get('/api/app/pending?user_id=usr_nonexistent').expect(403);
-    expect(emptyRes.body.error).toBe('INVALID_USER');
-
-    const missingRes = await api.get('/api/app/pending').expect(400);
-    expect(missingRes.body.error).toBe('MISSING_USER_ID');
+    const unauthorizedRes = await api.get('/api/app/pending').expect(401);
+    expect(unauthorizedRes.body.error).toBe('UNAUTHORIZED');
   });
 
   it('GET /api/app/history returns all actions for user sorted by created_at DESC', async () => {
     const api = request(runtime.app);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
 
-    const historyRes = await api.get('/api/app/history?user_id=usr_demo&limit=50&offset=0').expect(200);
+    const historyRes = await api.get('/api/app/history?limit=50&offset=0').set('Cookie', [appCookie]).expect(200);
     expect(historyRes.body.items.length).toBeGreaterThanOrEqual(3);
     expect(typeof historyRes.body.total).toBe('number');
     expect(historyRes.body.limit).toBe(50);
@@ -553,15 +549,12 @@ describe('Aegis MVP prototype', () => {
     expect(statuses.some((s: string) => s === 'awaiting_approval')).toBe(true);
     expect(statuses.some((s: string) => s !== 'awaiting_approval')).toBe(true);
 
-    const paginatedRes = await api.get('/api/app/history?user_id=usr_demo&limit=2&offset=0').expect(200);
+    const paginatedRes = await api.get('/api/app/history?limit=2&offset=0').set('Cookie', [appCookie]).expect(200);
     expect(paginatedRes.body.items.length).toBeLessThanOrEqual(2);
     expect(paginatedRes.body.total).toBe(historyRes.body.total);
 
-    const emptyRes = await api.get('/api/app/history?user_id=usr_nonexistent').expect(403);
-    expect(emptyRes.body.error).toBe('INVALID_USER');
-
-    const missingRes = await api.get('/api/app/history').expect(400);
-    expect(missingRes.body.error).toBe('MISSING_USER_ID');
+    const unauthorizedRes = await api.get('/api/app/history').expect(401);
+    expect(unauthorizedRes.body.error).toBe('UNAUTHORIZED');
   });
 
   it('GET /api/app/admin/history supports status filter and keeps admin auth', async () => {
@@ -816,46 +809,49 @@ describe('Aegis MVP prototype', () => {
 
   it('device registration: POST, GET, upsert, DELETE', async () => {
     const api = request(runtime.app);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
 
     const reg1 = await api
       .post('/api/app/devices')
-      .send({ user_id: 'usr_demo', platform: 'ios', push_token: 'apns_token_abc' })
+      .set('Cookie', [appCookie])
+      .send({ platform: 'ios', push_token: 'apns_token_abc' })
       .expect(200);
     expect(reg1.body.ok).toBe(true);
     expect(reg1.body.device_id).toBeTruthy();
     const deviceId = reg1.body.device_id;
 
-    const list1 = await api.get('/api/app/devices?user_id=usr_demo').expect(200);
+    const list1 = await api.get('/api/app/devices').set('Cookie', [appCookie]).expect(200);
     expect(list1.body.devices.some((d: any) => d.id === deviceId && d.push_token === 'apns_token_abc')).toBe(true);
 
     const reg2 = await api
       .post('/api/app/devices')
-      .send({ user_id: 'usr_demo', platform: 'ios', push_token: 'apns_token_updated' })
+      .set('Cookie', [appCookie])
+      .send({ platform: 'ios', push_token: 'apns_token_updated' })
       .expect(200);
     expect(reg2.body.device_id).toBe(deviceId);
 
-    const list2 = await api.get('/api/app/devices?user_id=usr_demo').expect(200);
+    const list2 = await api.get('/api/app/devices').set('Cookie', [appCookie]).expect(200);
     const iosDevice = list2.body.devices.find((d: any) => d.id === deviceId);
     expect(iosDevice.push_token).toBe('apns_token_updated');
 
     const regAndroid = await api
       .post('/api/app/devices')
-      .send({ user_id: 'usr_demo', platform: 'android', push_token: 'fcm_token_xyz' })
+      .set('Cookie', [appCookie])
+      .send({ platform: 'android', push_token: 'fcm_token_xyz' })
       .expect(200);
     expect(regAndroid.body.device_id).toBeTruthy();
     expect(regAndroid.body.device_id).not.toBe(deviceId);
 
-    await api.delete(`/api/app/devices/${deviceId}?user_id=usr_demo`).expect(200);
-    const list3 = await api.get('/api/app/devices?user_id=usr_demo').expect(200);
+    await api.delete(`/api/app/devices/${deviceId}`).set('Cookie', [appCookie]).expect(200);
+    const list3 = await api.get('/api/app/devices').set('Cookie', [appCookie]).expect(200);
     expect(list3.body.devices.some((d: any) => d.id === deviceId)).toBe(false);
 
-    await api.delete('/api/app/devices/nonexistent?user_id=usr_demo').expect(404);
-    await api.delete(`/api/app/devices/${regAndroid.body.device_id}?user_id=usr_nonexistent`).expect(403);
+    await api.delete('/api/app/devices/nonexistent').set('Cookie', [appCookie]).expect(404);
+    await api.delete(`/api/app/devices/${regAndroid.body.device_id}`).expect(401);
 
-    await api.post('/api/app/devices').send({ user_id: 'usr_demo' }).expect(400);
-    await api.post('/api/app/devices').send({ user_id: 'usr_demo', platform: 'windows', push_token: 'x' }).expect(400);
-    const missingUserId = await api.get('/api/app/devices');
-    expect([400, 401]).toContain(missingUserId.status);
+    await api.post('/api/app/devices').set('Cookie', [appCookie]).send({}).expect(400);
+    await api.post('/api/app/devices').set('Cookie', [appCookie]).send({ platform: 'windows', push_token: 'x' }).expect(400);
+    await api.get('/api/app/devices').expect(401);
   });
 
   it('webhook deliveries include X-Aegis-Signature header', async () => {
@@ -909,6 +905,7 @@ describe('Aegis MVP prototype', () => {
 
   it('rejects action_id mobile approval flows for inactive users', async () => {
     const api = request(runtime.app);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
     const create = await api
       .post('/v1/request_action')
       .set('x-aegis-api-key', 'aegis_demo_agent_key')
@@ -932,10 +929,11 @@ describe('Aegis MVP prototype', () => {
     const actionId = String(create.body.action.action_id);
     runtime.service.getStore().getRawDb().prepare('UPDATE end_users SET status = ? WHERE id = ?').run('inactive', 'usr_demo');
     try {
-      await api.get(`/api/app/approval?action_id=${encodeURIComponent(actionId)}&user_id=usr_demo`).expect(403);
+      await api.get(`/api/app/approval?action_id=${encodeURIComponent(actionId)}`).set('Cookie', [appCookie]).expect(403);
       await api
         .post('/api/app/approval/decision')
-        .send({ action_id: actionId, user_id: 'usr_demo', decision: 'approve', decision_source: 'web_magic_link' })
+        .set('Cookie', [appCookie])
+        .send({ action_id: actionId, decision: 'approve', decision_source: 'web_magic_link' })
         .expect(403);
     } finally {
       runtime.service.getStore().getRawDb().prepare('UPDATE end_users SET status = ? WHERE id = ?').run('active', 'usr_demo');
@@ -944,6 +942,7 @@ describe('Aegis MVP prototype', () => {
 
   it('rejects action_id approval decision for non-target active user with explicit error code', async () => {
     const api = request(runtime.app);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
     const create = await api
       .post('/v1/request_action')
       .set('x-aegis-api-key', 'aegis_demo_agent_key')
@@ -971,6 +970,7 @@ describe('Aegis MVP prototype', () => {
 
     const res = await api
       .post('/api/app/approval/decision')
+      .set('Cookie', [appCookie])
       .send({ action_id: actionId, user_id: 'usr_other_active', decision: 'approve', decision_source: 'app_biometric' })
       .expect(403);
 


### PR DESCRIPTION
## Summary
- Enforced app session auth for user-scoped app APIs: `/api/app/pending`, `/api/app/history`, and `/api/app/devices*`.
- Removed insecure `user_id`-only trust path for these endpoints; user identity now comes from `aegis_app_session`.
- Hardened action-id approval path: `/api/app/approval` and `/api/app/approval/decision` now require app session when using `action_id` (token path remains compatible).
- Added explicit mismatch rejection when request body `user_id` does not match session user on action-id path.
- Updated integration tests to use `_test/app-session` cookie flow and verify unauthorized access fails.

## Test Commands & Results
- `npm run build` ✅
- `npm test` ✅ (18 files, 178 tests)
- `npx vitest run --coverage` ✅

## Risks
- Behavior change for clients that previously called app endpoints with only `user_id` query/body; they must now authenticate via app session cookie.
- Existing non-session mobile test harnesses/scripts may fail until updated.

## Rollback Plan
- Revert commit `6c4c747` to restore previous `user_id`-based behavior.
- If partial rollback needed, restore `requireValidUser` path in `src/routes/app.ts` and corresponding tests in `tests/app.test.ts`.

Closes #6

---
API 行为变化：
- `/api/app/pending|history|devices*` 改为 session-only；不再接受仅 `user_id` 作为身份凭据。
- `/api/app/approval` 与 `/api/app/approval/decision` 在 `action_id` 分支改为必须有 app session；`token` 分支保持兼容。

错误码变化：
- 新增/强化 `UNAUTHORIZED`（401）用于无效/缺失 app session。
- `APPROVAL_NOT_ASSIGNED_TO_USER`（403）用于 action_id 分支的 session-user/body-user 不匹配。

新增/修改测试：
- 修改 `tests/app.test.ts`：approval(action_id)、pending/history、devices 全部转为 session 场景并增加未登录拒绝断言。

风险：
- 依赖旧 `user_id` 直传的调用方需同步迁移。

回滚：
- 直接回滚本 PR 提交即可。
