### PR TITLE
[#5] Productionize payment execution (Stripe/SCA/no silent fallback)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ export function createAegisApp(partialConfig?: Partial<AppConfig>): AppRuntime {
   const store = new AegisStore(db);
   const sandboxFaults = new SandboxFaultService();
   const notifications = new NotificationService(store, config);
-  const executionEngine = new ExecutionEngine(sandboxFaults, config.stripeSecretKey);
+  const executionEngine = new ExecutionEngine(sandboxFaults, config.stripeSecretKey, config.allowMockCardExecution);
   const webhookSender = new WebhookSender(config);
   const service = new AegisService(store, notifications, executionEngine, webhookSender, config);
   const adminAuth = new AdminAuthService(config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export interface AppConfig {
   appSessionTtlMinutes: number;
   stripeSecretKey: string | null;
   stripePublishableKey: string | null;
+  allowMockCardExecution: boolean;
   googleClientId: string | null;
   googleClientSecret: string | null;
 }
@@ -49,6 +50,7 @@ export function loadConfig(): AppConfig {
     appSessionTtlMinutes: Number(process.env.APP_SESSION_TTL_MINUTES ?? 10080), // 7 days
     stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? null,
     stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY ?? null,
+    allowMockCardExecution: boolFromEnv(process.env.ALLOW_MOCK_CARD_EXECUTION, process.env.NODE_ENV !== 'production'),
     googleClientId: process.env.GOOGLE_CLIENT_ID ?? null,
     googleClientSecret: process.env.GOOGLE_CLIENT_SECRET ?? null,
   };

--- a/src/services/execution.ts
+++ b/src/services/execution.ts
@@ -27,6 +27,7 @@ export class ExecutionEngine {
   constructor(
     private readonly sandboxFaults?: SandboxFaultService,
     stripeSecretKey?: string | null,
+    private readonly allowMockCardExecution = process.env.NODE_ENV !== 'production',
   ) {
     if (stripeSecretKey) {
       this.stripe = new Stripe(stripeSecretKey, { apiVersion: '2025-01-27.acacia' as any });
@@ -73,6 +74,15 @@ export class ExecutionEngine {
 
     if (this.stripe) {
       return this.executeCardStripe(action, paymentMethod);
+    }
+    if (!this.allowMockCardExecution) {
+      return {
+        success: false,
+        rail: 'card',
+        provider: 'stripe',
+        errorCode: 'PROVIDER_UNAVAILABLE',
+        errorMessage: 'Stripe is not configured for card execution in this environment',
+      };
     }
     return this.executeCardMock(action, paymentMethod);
   }

--- a/tests/unit/execution.test.ts
+++ b/tests/unit/execution.test.ts
@@ -34,7 +34,7 @@ function mockPaymentMethod(rail: 'card' | 'crypto'): PaymentMethodRecord {
 
 describe('execution', () => {
   describe('ExecutionEngine without Stripe', () => {
-    const engine = new ExecutionEngine(undefined, undefined);
+    const engine = new ExecutionEngine(undefined, undefined, true);
 
     it('isStripeEnabled is false', () => {
       expect(engine.isStripeEnabled).toBe(false);
@@ -64,13 +64,23 @@ describe('execution', () => {
       expect(result.success).toBe(false);
       expect(result.errorCode).toBe('INVALID_PAYMENT_METHOD');
     });
+
+    it('returns PROVIDER_UNAVAILABLE when mock fallback is disabled', async () => {
+      const strictEngine = new ExecutionEngine(undefined, undefined, false);
+      const action = mockAction({ payment_rail: 'card' });
+      const pm = mockPaymentMethod('card');
+      const result = await strictEngine.execute(action, pm);
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('PROVIDER_UNAVAILABLE');
+      expect(result.provider).toBe('stripe');
+    });
   });
 
   describe('ExecutionEngine with sandbox fault', () => {
     it('injects decline for card', async () => {
       const sandbox = new SandboxFaultService();
       sandbox.setCardFault('decline');
-      const engine = new ExecutionEngine(sandbox, undefined);
+      const engine = new ExecutionEngine(sandbox, undefined, true);
       const action = mockAction({ payment_rail: 'card' });
       const pm = mockPaymentMethod('card');
       const result = await engine.execute(action, pm);
@@ -81,7 +91,7 @@ describe('execution', () => {
     it('injects timeout for card', async () => {
       const sandbox = new SandboxFaultService();
       sandbox.setCardFault('timeout');
-      const engine = new ExecutionEngine(sandbox, undefined);
+      const engine = new ExecutionEngine(sandbox, undefined, true);
       const action = mockAction({ payment_rail: 'card' });
       const pm = mockPaymentMethod('card');
       const result = await engine.execute(action, pm);
@@ -92,7 +102,7 @@ describe('execution', () => {
     it('fault is consumed once (scope once)', async () => {
       const sandbox = new SandboxFaultService();
       sandbox.setCardFault('decline', 'once');
-      const engine = new ExecutionEngine(sandbox, undefined);
+      const engine = new ExecutionEngine(sandbox, undefined, true);
       const action = mockAction({ payment_rail: 'card', recipient_reference: 'merchant_api:test' });
       const pm = mockPaymentMethod('card');
       const r1 = await engine.execute(action, pm);


### PR DESCRIPTION
## Summary
- Productionized card execution behavior by disabling implicit mock PSP fallback in production-like environments.
- Added `allowMockCardExecution` config (`ALLOW_MOCK_CARD_EXECUTION` env) with default: `false` in production, `true` otherwise.
- Updated app runtime wiring to pass the new execution fallback policy into `ExecutionEngine`.
- When Stripe is not configured and mock fallback is disabled, card execution now fails explicitly with `PROVIDER_UNAVAILABLE` instead of silently succeeding.
- Added unit coverage for strict-mode behavior (`PROVIDER_UNAVAILABLE`).

## Test Commands & Results
- `npm run build` ✅
- `npm test` ✅ (18 files, 179 tests)
- `npx vitest run --coverage` ✅

## Risks
- Environments that relied on implicit card mock execution without Stripe may now see `PROVIDER_UNAVAILABLE` if configured with production defaults.
- Misconfigured staging/prod (missing Stripe key) will fail fast on card execution; this is intentional but operationally visible.

## Rollback Plan
- Revert commit `93c7f0c` to restore previous fallback behavior.
- Operational workaround without rollback: set `ALLOW_MOCK_CARD_EXECUTION=true` temporarily.

Closes #5

---
API 行为变化：
- 无外部 API 路由变更；执行行为变更体现在 action execution 结果。

错误码变化：
- `PROVIDER_UNAVAILABLE`：Stripe 未配置且 mock fallback 被禁用时返回（card rail）。

新增/修改测试：
- `tests/unit/execution.test.ts` 新增 strict-mode 单测，断言 `PROVIDER_UNAVAILABLE`。

风险：
- 依赖隐式 mock 执行的环境会暴露配置问题。

回滚：
- 回滚本 PR 提交，或临时启用 `ALLOW_MOCK_CARD_EXECUTION=true`。
