### PR TITLE
[#7] Control plane guardrails (keys/limits/allowlist/rotation)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -261,6 +261,26 @@ function migrate(db: Database.Database): void {
       FOREIGN KEY (end_user_id) REFERENCES end_users(id),
       FOREIGN KEY (plan_id) REFERENCES plans(id)
     );
+
+    CREATE TABLE IF NOT EXISTS risk_policies (
+      id TEXT PRIMARY KEY,
+      single_tx_limit_cents INTEGER NOT NULL,
+      daily_total_limit_cents INTEGER NOT NULL,
+      allowlist_enabled INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS recipient_allowlist (
+      recipient_reference TEXT PRIMARY KEY,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS key_rate_limits (
+      agent_id TEXT PRIMARY KEY,
+      requests_per_minute INTEGER NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (agent_id) REFERENCES agents(id)
+    );
   `);
 
   // Backfill owner_user_id for existing agents table (SQLite: add column if missing)
@@ -359,6 +379,18 @@ function seed(db: Database.Database): void {
   const userPlanCount = db.prepare('SELECT COUNT(1) as c FROM user_plans WHERE end_user_id = ?').get('usr_demo') as { c: number };
   if (userPlanCount.c === 0) {
     db.prepare('INSERT INTO user_plans (end_user_id, plan_id, created_at) VALUES (?, ?, ?)').run('usr_demo', 'plan_free', now);
+  }
+
+  const riskPolicyCount = db.prepare('SELECT COUNT(1) as c FROM risk_policies').get() as { c: number };
+  if (riskPolicyCount.c === 0) {
+    db.prepare(
+      'INSERT INTO risk_policies (id, single_tx_limit_cents, daily_total_limit_cents, allowlist_enabled, updated_at) VALUES (?, ?, ?, ?, ?)'
+    ).run('global', 200_000, 1_000_000, 0, now);
+  }
+
+  const keyRateCount = db.prepare('SELECT COUNT(1) as c FROM key_rate_limits WHERE agent_id = ?').get('agt_demo') as { c: number };
+  if (keyRateCount.c === 0) {
+    db.prepare('INSERT INTO key_rate_limits (agent_id, requests_per_minute, updated_at) VALUES (?, ?, ?)').run('agt_demo', 60, now);
   }
 
   const existingDocs = db.prepare('SELECT COUNT(1) as c FROM email_outbox').get() as { c: number };

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -209,6 +209,104 @@ export function createApiRouter(service: AegisService, sandboxFaults: SandboxFau
     }
   });
 
+  // ─── Admin Control (internal) ───────────────────────────────────────
+  router.get('/api/dev/admin-control/keys', (_req, res, next) => {
+    try {
+      res.json({ keys: service.listAgentKeyControls() });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/api/dev/admin-control/keys/:agentId', (req, res, next) => {
+    try {
+      res.json({ key: service.getAgentKeyControl(String(req.params.agentId)) });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/api/dev/admin-control/keys/:agentId/status', (req, res, next) => {
+    try {
+      const status = String(req.body?.status ?? '').trim();
+      if (status !== 'active' && status !== 'disabled') {
+        throw new DomainError('INVALID_STATUS', 'status must be active or disabled', 400);
+      }
+      const key = service.setAgentKeyStatus(String(req.params.agentId), status);
+      res.json({ ok: true, key });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/api/dev/admin-control/keys/:agentId/rotate', (req, res, next) => {
+    try {
+      const rotated = service.rotateAgentCredentials(String(req.params.agentId));
+      res.json({ ok: true, ...rotated });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/api/dev/admin-control/keys/:agentId/rate-limit', (req, res, next) => {
+    try {
+      const requestsPerMinute = Number(req.body?.requests_per_minute);
+      const rate = service.setAgentRateLimit(String(req.params.agentId), requestsPerMinute);
+      res.json({ ok: true, rate_limit: rate });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/api/dev/admin-control/policies/risk', (_req, res, next) => {
+    try {
+      res.json({ policy: service.getRiskPolicy() });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/api/dev/admin-control/policies/risk', (req, res, next) => {
+    try {
+      const policy = service.updateRiskPolicy({
+        single_tx_limit_cents: Number(req.body?.single_tx_limit_cents),
+        daily_total_limit_cents: Number(req.body?.daily_total_limit_cents),
+        allowlist_enabled: Boolean(req.body?.allowlist_enabled),
+      });
+      res.json({ ok: true, policy });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/api/dev/admin-control/policies/allowlist', (_req, res, next) => {
+    try {
+      const policy = service.getRiskPolicy();
+      const recipients = service.getRecipientAllowlist();
+      res.json({ allowlist_enabled: policy.allowlist_enabled, recipients });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/api/dev/admin-control/policies/allowlist', (req, res, next) => {
+    try {
+      const recipientsRaw = Array.isArray(req.body?.recipients) ? req.body.recipients : [];
+      const recipients = recipientsRaw.map((v: unknown) => String(v)).filter(Boolean);
+      if (typeof req.body?.allowlist_enabled !== 'undefined') {
+        service.updateRiskPolicy({
+          ...service.getRiskPolicy(),
+          allowlist_enabled: Boolean(req.body.allowlist_enabled),
+        });
+      }
+      const updated = service.updateRecipientAllowlist(recipients);
+      const policy = service.getRiskPolicy();
+      res.json({ ok: true, allowlist_enabled: policy.allowlist_enabled, recipients: updated });
+    } catch (error) {
+      next(error);
+    }
+  });
+
   // ─── Dev: Payment methods (Stripe Elements add card) ───────────────
   router.post('/api/dev/payment-methods', async (req, res, next) => {
     try {

--- a/src/services/aegis.ts
+++ b/src/services/aegis.ts
@@ -1,5 +1,5 @@
 import { AppConfig } from '../config';
-import { safeJsonParse } from '../lib/crypto';
+import { randomId, safeJsonParse, sha256 } from '../lib/crypto';
 import { nowIso } from '../lib/time';
 import { TERMINAL_STATUSES } from '../types';
 import {
@@ -46,6 +46,97 @@ export class AegisService {
 
   getConfig(): AppConfig {
     return this.config;
+  }
+
+  listAgentKeyControls() {
+    return this.store.listAgents().map((a) => {
+      const rate = this.store.getKeyRateLimit(a.id);
+      return {
+        agent_id: a.id,
+        name: a.name,
+        status: a.status,
+        requests_per_minute: rate?.requests_per_minute ?? null,
+      };
+    });
+  }
+
+  getAgentKeyControl(agentId: string) {
+    const agent = this.store.getAgentById(agentId);
+    if (!agent) throw new DomainError('NOT_FOUND', 'Agent not found', 404);
+    const rate = this.store.getKeyRateLimit(agentId);
+    return {
+      agent_id: agent.id,
+      name: agent.name,
+      status: agent.status,
+      requests_per_minute: rate?.requests_per_minute ?? null,
+    };
+  }
+
+  setAgentKeyStatus(agentId: string, status: 'active' | 'disabled') {
+    if (!this.store.setAgentStatus(agentId, status)) {
+      throw new DomainError('NOT_FOUND', 'Agent not found', 404);
+    }
+    return this.getAgentKeyControl(agentId);
+  }
+
+  rotateAgentCredentials(agentId: string) {
+    const agent = this.store.getAgentById(agentId);
+    if (!agent) throw new DomainError('NOT_FOUND', 'Agent not found', 404);
+    const rawApiKey = `aegis_${randomId('key').replace(/^key_/, '')}`;
+    const webhookSecret = `whsec_${randomId('wh').replace(/^wh_/, '')}`;
+    this.store.rotateAgentSecrets(agentId, sha256(rawApiKey), webhookSecret);
+    return { agent_id: agentId, api_key: rawApiKey, webhook_secret: webhookSecret };
+  }
+
+  setAgentRateLimit(agentId: string, requestsPerMinute: number) {
+    const agent = this.store.getAgentById(agentId);
+    if (!agent) throw new DomainError('NOT_FOUND', 'Agent not found', 404);
+    if (!Number.isInteger(requestsPerMinute) || requestsPerMinute <= 0) {
+      throw new DomainError('INVALID_RATE_LIMIT', 'requests_per_minute must be a positive integer', 400);
+    }
+    const row = this.store.setKeyRateLimit(agentId, requestsPerMinute);
+    return { agent_id: row.agent_id, requests_per_minute: row.requests_per_minute, updated_at: row.updated_at };
+  }
+
+  getRiskPolicy() {
+    const p = this.store.getRiskPolicy();
+    return {
+      single_tx_limit_cents: p.single_tx_limit_cents,
+      daily_total_limit_cents: p.daily_total_limit_cents,
+      allowlist_enabled: Boolean(p.allowlist_enabled),
+      updated_at: p.updated_at,
+    };
+  }
+
+  updateRiskPolicy(input: { single_tx_limit_cents: number; daily_total_limit_cents: number; allowlist_enabled: boolean }) {
+    if (!Number.isInteger(input.single_tx_limit_cents) || input.single_tx_limit_cents <= 0) {
+      throw new DomainError('INVALID_SINGLE_TX_LIMIT', 'single_tx_limit_cents must be a positive integer', 400);
+    }
+    if (!Number.isInteger(input.daily_total_limit_cents) || input.daily_total_limit_cents <= 0) {
+      throw new DomainError('INVALID_DAILY_LIMIT', 'daily_total_limit_cents must be a positive integer', 400);
+    }
+    if (input.daily_total_limit_cents < input.single_tx_limit_cents) {
+      throw new DomainError('INVALID_LIMITS', 'daily_total_limit_cents must be >= single_tx_limit_cents', 400);
+    }
+    const p = this.store.updateRiskPolicy({
+      singleTxLimitCents: input.single_tx_limit_cents,
+      dailyTotalLimitCents: input.daily_total_limit_cents,
+      allowlistEnabled: input.allowlist_enabled,
+    });
+    return {
+      single_tx_limit_cents: p.single_tx_limit_cents,
+      daily_total_limit_cents: p.daily_total_limit_cents,
+      allowlist_enabled: Boolean(p.allowlist_enabled),
+      updated_at: p.updated_at,
+    };
+  }
+
+  getRecipientAllowlist() {
+    return this.store.listRecipientAllowlist().map((r) => r.recipient_reference);
+  }
+
+  updateRecipientAllowlist(recipientReferences: string[]) {
+    return this.store.replaceRecipientAllowlist(recipientReferences).map((r) => r.recipient_reference);
   }
 
   requestLoginMagicLink(email: string): { ok: true; message: string } {

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -109,6 +109,20 @@ export interface DeviceRecord {
   updated_at: string;
 }
 
+export interface RiskPolicyRecord {
+  id: string;
+  single_tx_limit_cents: number;
+  daily_total_limit_cents: number;
+  allowlist_enabled: number;
+  updated_at: string;
+}
+
+export interface KeyRateLimitRecord {
+  agent_id: string;
+  requests_per_minute: number;
+  updated_at: string;
+}
+
 export class AegisStore {
   constructor(private readonly db: Database.Database) {}
 
@@ -129,6 +143,18 @@ export class AegisStore {
 
   listAgents(): AgentRecord[] {
     return this.db.prepare('SELECT * FROM agents ORDER BY created_at DESC').all() as AgentRecord[];
+  }
+
+  setAgentStatus(agentId: string, status: 'active' | 'disabled'): boolean {
+    const result = this.db.prepare('UPDATE agents SET status = ? WHERE id = ?').run(status, agentId);
+    return result.changes > 0;
+  }
+
+  rotateAgentSecrets(agentId: string, nextApiKeyHash: string, nextWebhookSecret: string): boolean {
+    const result = this.db
+      .prepare('UPDATE agents SET api_key_hash = ?, webhook_secret = ? WHERE id = ?')
+      .run(nextApiKeyHash, nextWebhookSecret, agentId);
+    return result.changes > 0;
   }
 
   listAgentsByOwner(ownerUserId: string): AgentRecord[] {
@@ -408,6 +434,61 @@ export class AegisStore {
       .prepare(`SELECT * FROM actions ${whereSql} ORDER BY datetime(created_at) DESC LIMIT ? OFFSET ?`)
       .all(...params, limit, offset) as ActionRecord[];
     return { rows, total };
+  }
+
+  getRiskPolicy(): RiskPolicyRecord {
+    const row = this.db.prepare('SELECT * FROM risk_policies WHERE id = ?').get('global') as RiskPolicyRecord | undefined;
+    if (!row) throw new Error('Risk policy not initialized');
+    return row;
+  }
+
+  updateRiskPolicy(input: { singleTxLimitCents: number; dailyTotalLimitCents: number; allowlistEnabled: boolean }): RiskPolicyRecord {
+    const now = nowIso();
+    this.db
+      .prepare(
+        'UPDATE risk_policies SET single_tx_limit_cents = ?, daily_total_limit_cents = ?, allowlist_enabled = ?, updated_at = ? WHERE id = ?'
+      )
+      .run(input.singleTxLimitCents, input.dailyTotalLimitCents, input.allowlistEnabled ? 1 : 0, now, 'global');
+    return this.getRiskPolicy();
+  }
+
+  listRecipientAllowlist(): Array<{ recipient_reference: string; created_at: string }> {
+    return this.db
+      .prepare('SELECT recipient_reference, created_at FROM recipient_allowlist ORDER BY created_at ASC')
+      .all() as Array<{ recipient_reference: string; created_at: string }>;
+  }
+
+  replaceRecipientAllowlist(recipientReferences: string[]): Array<{ recipient_reference: string; created_at: string }> {
+    const now = nowIso();
+    const unique = Array.from(new Set(recipientReferences.map((r) => r.trim()).filter(Boolean)));
+    const tx = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM recipient_allowlist').run();
+      const stmt = this.db.prepare('INSERT INTO recipient_allowlist (recipient_reference, created_at) VALUES (?, ?)');
+      for (const ref of unique) {
+        stmt.run(ref, now);
+      }
+    });
+    tx();
+    return this.listRecipientAllowlist();
+  }
+
+  getKeyRateLimit(agentId: string): KeyRateLimitRecord | null {
+    const row = this.db
+      .prepare('SELECT agent_id, requests_per_minute, updated_at FROM key_rate_limits WHERE agent_id = ?')
+      .get(agentId) as KeyRateLimitRecord | undefined;
+    return row ?? null;
+  }
+
+  setKeyRateLimit(agentId: string, requestsPerMinute: number): KeyRateLimitRecord {
+    const now = nowIso();
+    this.db
+      .prepare(
+        `INSERT INTO key_rate_limits (agent_id, requests_per_minute, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(agent_id) DO UPDATE SET requests_per_minute=excluded.requests_per_minute, updated_at=excluded.updated_at`
+      )
+      .run(agentId, requestsPerMinute, now);
+    return this.getKeyRateLimit(agentId)!;
   }
 
   transitionActionStatus(opts: TransitionActionOptions): ActionRecord {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -591,6 +591,78 @@ describe('Aegis MVP prototype', () => {
     expect(invalidStatus.body.error).toBe('INVALID_STATUS');
   });
 
+  it('admin-control guardrails: keys, status, rotation, limits, allowlist are admin-only', async () => {
+    const api = request(runtime.app);
+
+    await api.get('/api/dev/admin-control/keys').expect(401);
+
+    const adminCookie = await adminLogin(api);
+    const appCookie = await getAppSessionCookie(api, 'usr_demo');
+    const created = await api.post('/api/app/agents').set('Cookie', [appCookie]).send({ name: 'Guardrail Test Agent' }).expect(201);
+    const testAgentId = String(created.body.agent.id);
+
+    const keysRes = await api.get('/api/dev/admin-control/keys').set('Cookie', [adminCookie]).expect(200);
+    expect(Array.isArray(keysRes.body.keys)).toBe(true);
+    expect(keysRes.body.keys.some((k: any) => k.agent_id === 'agt_demo')).toBe(true);
+    expect(keysRes.body.keys.some((k: any) => k.agent_id === testAgentId)).toBe(true);
+
+    const detailRes = await api.get(`/api/dev/admin-control/keys/${encodeURIComponent(testAgentId)}`).set('Cookie', [adminCookie]).expect(200);
+    expect(detailRes.body.key.status).toMatch(/active|disabled/);
+
+    const disabledRes = await api
+      .post(`/api/dev/admin-control/keys/${encodeURIComponent(testAgentId)}/status`)
+      .set('Cookie', [adminCookie])
+      .send({ status: 'disabled' })
+      .expect(200);
+    expect(disabledRes.body.key.status).toBe('disabled');
+
+    const enabledRes = await api
+      .post(`/api/dev/admin-control/keys/${encodeURIComponent(testAgentId)}/status`)
+      .set('Cookie', [adminCookie])
+      .send({ status: 'active' })
+      .expect(200);
+    expect(enabledRes.body.key.status).toBe('active');
+
+    const rotateRes = await api
+      .post(`/api/dev/admin-control/keys/${encodeURIComponent(testAgentId)}/rotate`)
+      .set('Cookie', [adminCookie])
+      .send({})
+      .expect(200);
+    expect(rotateRes.body.api_key).toMatch(/^aegis_/);
+    expect(rotateRes.body.webhook_secret).toMatch(/^whsec_/);
+
+    const rateRes = await api
+      .put(`/api/dev/admin-control/keys/${encodeURIComponent(testAgentId)}/rate-limit`)
+      .set('Cookie', [adminCookie])
+      .send({ requests_per_minute: 120 })
+      .expect(200);
+    expect(rateRes.body.rate_limit.requests_per_minute).toBe(120);
+
+    const riskGet = await api.get('/api/dev/admin-control/policies/risk').set('Cookie', [adminCookie]).expect(200);
+    expect(riskGet.body.policy.single_tx_limit_cents).toBeTypeOf('number');
+
+    const riskPut = await api
+      .put('/api/dev/admin-control/policies/risk')
+      .set('Cookie', [adminCookie])
+      .send({ single_tx_limit_cents: 300000, daily_total_limit_cents: 1200000, allowlist_enabled: true })
+      .expect(200);
+    expect(riskPut.body.policy.allowlist_enabled).toBe(true);
+
+    const allowPut = await api
+      .put('/api/dev/admin-control/policies/allowlist')
+      .set('Cookie', [adminCookie])
+      .send({ recipients: ['merchant_api:a', 'merchant_api:b'], allowlist_enabled: true })
+      .expect(200);
+    expect(allowPut.body.recipients).toContain('merchant_api:a');
+
+    const allowGet = await api
+      .get('/api/dev/admin-control/policies/allowlist')
+      .set('Cookie', [adminCookie])
+      .expect(200);
+    expect(allowGet.body.allowlist_enabled).toBe(true);
+    expect(allowGet.body.recipients).toContain('merchant_api:b');
+  });
+
   it('POST /v1/request_action returns Idempotency-Key header and Idempotency-Replayed on replay', async () => {
     const api = request(runtime.app);
     const body = {


### PR DESCRIPTION
## Summary
- Added internal admin-control guardrails endpoints under `/api/dev/admin-control/*` (admin session protected).
- Added key control operations: list/read key state, set key status (`active|disabled`), rotate API key + webhook secret, update per-key rate limit policy.
- Added policy stores and APIs for spending limits and recipient allowlist (`risk_policies`, `recipient_allowlist`, `key_rate_limits`).
- Added service/store methods to enforce validation and standardize admin-control responses.
- Added integration coverage for admin-only boundary and guardrail workflows (status toggle, rotation, rate-limit update, risk policy update, allowlist update/read).

## Test Commands & Results
- `npm run build` ✅
- `npm test` ✅ (18 files, 179 tests)
- `npx vitest run --coverage` ✅

## Risks
- API key rotation is now possible from admin-control; downstream systems must consume newly issued key and secure storage process must be in place.
- Per-key rate-limit in this PR is policy/config surface (read/write) only; runtime limiter enforcement is not included in this issue PR.

## Rollback Plan
- Revert commit `16f1c63` to remove admin-control guardrail surfaces and schema additions.
- If partial rollback needed, disable `/api/dev/admin-control/*` routes while retaining DB schema (non-breaking).

Closes #7

---
API 行为变化：
- 新增内部接口：
  - `GET /api/dev/admin-control/keys`
  - `GET /api/dev/admin-control/keys/:agentId`
  - `POST /api/dev/admin-control/keys/:agentId/status`
  - `POST /api/dev/admin-control/keys/:agentId/rotate`
  - `PUT /api/dev/admin-control/keys/:agentId/rate-limit`
  - `GET/PUT /api/dev/admin-control/policies/risk`
  - `GET/PUT /api/dev/admin-control/policies/allowlist`

错误码变化：
- `INVALID_STATUS`、`INVALID_RATE_LIMIT`、`INVALID_SINGLE_TX_LIMIT`、`INVALID_DAILY_LIMIT`、`INVALID_LIMITS`（admin-control 请求参数非法时）。

新增/修改测试：
- `tests/app.test.ts` 新增 `admin-control guardrails: keys, status, rotation, limits, allowlist are admin-only`。

风险：
- key rotation 会使旧 key 立即失效，需运维流程保障。

回滚：
- 回滚本 PR 提交，或先禁用新增 admin-control 路由。
